### PR TITLE
Suppress transient connection error noise in error tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.31.2
+
+- **FIX**: Skip th first 3 connection error reporting to suppress Android DSN errors noise.
+
 ## 0.31.1
 
 - **FEAT**: Expand query error reporting.

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -205,6 +205,18 @@ final class WebSocketConnection extends ValueNotifier<HordaConnectionState>
         return;
       }
 
+      if (!connected) {
+        _connectFailureCount++;
+        if (_connectFailureCount >= 3) {
+          final err = _lastConnectError;
+          final stack = _lastConnectStack;
+          if (err != null && stack != null) {
+            system.errorTrackingService?.reportError(err, stack);
+          }
+          _connectFailureCount = 0;
+        }
+      }
+
       retries += 1;
     } while (!connected);
 
@@ -214,6 +226,7 @@ final class WebSocketConnection extends ValueNotifier<HordaConnectionState>
 
     _isConnected = true;
     _isFirstTimeConnect = false;
+    _connectFailureCount = 0;
 
     _drainQueue();
 
@@ -463,7 +476,8 @@ final class WebSocketConnection extends ValueNotifier<HordaConnectionState>
     } catch (e, stack) {
       logger.warning('web socket connect exception, url($_url): $e');
 
-      system.errorTrackingService?.reportError(e, stack);
+      _lastConnectError = e;
+      _lastConnectStack = stack;
 
       _close();
 
@@ -589,6 +603,9 @@ final class WebSocketConnection extends ValueNotifier<HordaConnectionState>
   bool _isFirstTimeConnect = true;
   final _streamGroup = StreamGroup<WsMessageBox>.broadcast();
   final _queue = Queue<WsMessageBox>();
+  int _connectFailureCount = 0;
+  Object? _lastConnectError;
+  StackTrace? _lastConnectStack;
 }
 
 class ConnectionException implements Exception {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: horda_client
 description: Connect your Flutter app to backends built with the Horda platform.
-version: 0.31.1
+version: 0.31.2
 homepage: https://github.com/horda-ai/dart_client
 
 environment:


### PR DESCRIPTION
On Android, DNS resolution for the WebSocket host can fail transiently at app cold-start (Private DNS tunnel not ready, carrier DNS not yet assigned after wake, etc.). Because reportError was called on every failed _connect() attempt inside the unlimited retry loop, each transient DNS hiccup generated 3-5 separate Crashlytics entries even though the connection recovered on its own with no visible impact to the user.

Fix: move error reporting out of _connect() and into the open() retry loop, reporting only after 3 consecutive failures — same threshold used by watchConnectionStability in delurk_client. A successful connection resets the counter so subsequent transient failures are evaluated independently.